### PR TITLE
[Forwardport] Added language translation for comment tag

### DIFF
--- a/app/code/Magento/Signifyd/etc/adminhtml/system.xml
+++ b/app/code/Magento/Signifyd/etc/adminhtml/system.xml
@@ -13,7 +13,7 @@
             <resource>Magento_Sales::fraud_protection</resource>
             <group id="signifyd" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="0">
                 <fieldset_css>signifyd-logo-header</fieldset_css>
-                <group id="about" translate="label" sortOrder="15" showInDefault="1" showInWebsite="1" showInStore="0">
+                <group id="about" translate="label comment" sortOrder="15" showInDefault="1" showInWebsite="1" showInStore="0">
                     <frontend_model>Magento\Signifyd\Block\Adminhtml\System\Config\Fieldset\Info</frontend_model>
                     <fieldset_css>signifyd-about-header</fieldset_css>
                     <label><![CDATA[Protect your store from fraud with Guaranteed Fraud Protection by Signifyd.]]></label>
@@ -26,12 +26,12 @@
                     </comment>
                     <more_url>https://www.signifyd.com/magento-guaranteed-fraud-protection</more_url>
                 </group>
-                <group id="config" translate="label" sortOrder="15" showInDefault="1" showInWebsite="1" showInStore="0">
+                <group id="config" translate="label comment" sortOrder="15" showInDefault="1" showInWebsite="1" showInStore="0">
                     <fieldset_css>signifyd-about-header</fieldset_css>
                     <label>Configuration</label>
                     <comment><![CDATA[<a href="https://www.signifyd.com/resources/manual/magento-2/signifyd-on-magento-integration-guide/" target="_blank">View our setup guide</a> for step-by-step instructions on how to integrate Signifyd with Magento.<br />For support contact <a href="mailto:support@signifyd.com">support@signifyd.com</a>.]]>
                     </comment>
-                    <field id="active" translate="label comment" type="select" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <field id="active" translate="label" type="select" showInDefault="1" showInWebsite="1" showInStore="0">
                         <label>Enable this Solution</label>
                         <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                         <config_path>fraud_protection/signifyd/active</config_path>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15364
<!--- Provide a general summary of the Pull Request in the Title above -->

### Descriptions
Added language translation for comment tags into `system.xml` file of Signifyd Magento module

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#15361: Comments are not translated for Signifyd module

### Manual testing scenarios
1. Add translation keys for all comments into `en_US.csv` file.
2. Flush Magento cache and check,

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
