### PR TITLE
[Backport] Added translation for comment tag

### DIFF
--- a/app/code/Magento/Msrp/etc/adminhtml/system.xml
+++ b/app/code/Magento/Msrp/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
         <section id="sales">
             <group id="msrp" translate="label" type="text" sortOrder="110" showInDefault="1" showInWebsite="1" showInStore="0">
                 <label>Minimum Advertised Price</label>
-                <field id="enabled" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
+                <field id="enabled" translate="label comment" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="0" canRestore="1">
                     <label>Enable MAP</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment>

--- a/app/code/Magento/Msrp/i18n/en_US.csv
+++ b/app/code/Magento/Msrp/i18n/en_US.csv
@@ -13,6 +13,7 @@ Price,Price
 "Add to Cart","Add to Cart"
 "Minimum Advertised Price","Minimum Advertised Price"
 "Enable MAP","Enable MAP"
+"<strong style=""color:red"">Warning!</strong> Enabling MAP by default will hide all product prices on Storefront.","<strong style=""color:red"">Warning!</strong> Enabling MAP by default will hide all product prices on Storefront."
 "Display Actual Price","Display Actual Price"
 "Default Popup Text Message","Default Popup Text Message"
 "Default ""What's This"" Text Message","Default ""What's This"" Text Message"


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/21175
### Description (*)
Added translation for `<comment>` tag and also added translation key.
Goto: STORES > Configuration > SALES > Sales > Minimum Advertised Price > Enable MAP

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. N/A

### Manual testing scenarios (*)
1. N/A

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
